### PR TITLE
Site-wide default page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>CS110 Homework1</title>
+		<title>Home</title>
 		<meta charset="utf-8">
 		<link rel="icon" type="image/png" href="http://icons.iconarchive.com/icons/iconarchive/red-orb-alphabet/256/Letter-R-icon.png">
 		<script>


### PR DESCRIPTION
Set the site-wide default page title to "Home" to address the lack of a consistent page title for basic usability and SEO.

---
<a href="https://cursor.com/background-agent?bcId=bc-a040de21-fb12-4300-8744-d182622b4e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a040de21-fb12-4300-8744-d182622b4e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

